### PR TITLE
Fix indexing of infected and susceptibles in tests

### DIFF
--- a/contagion_sim/multisim_model_evaluation.py
+++ b/contagion_sim/multisim_model_evaluation.py
@@ -79,7 +79,7 @@ class MultisimModelEvaluation(AbstractSimModel):
 
         # new positives per simulation
         new_I = np.full((self.n_nodes, self.n_sims), False)
-        new_I[new_positive] = True
+        new_I[new_positive.a] = True
         new_I = new_I & ~self.I
         self.I[new_I] = True
 
@@ -93,7 +93,7 @@ class MultisimModelEvaluation(AbstractSimModel):
 
         # remove infection from negative nodes
         new_S = np.full((self.n_nodes, self.n_sims), False)
-        new_S[new_negative] = True
+        new_S[new_negative.a] = True
         self.I = self.I & ~new_S
         self.R_t[new_S] = np.inf
 


### PR DESCRIPTION
In the code of `multisim_model_evaluation.py`, the observations are used to update the state of the epidemy. However, since the observations in the notebook are a DataFrame, and this (filtered) DataFrame is used as index, this causes all the values of the DataFrame in all columns (both node index, value of the observation and time of observation) to be used as indices.

I think it would be much better to use only the node index column ("a") since otherwise the individual 1 would always be infected (1 is the value for the "infected" observation) and 0 would be always susceptible (for the same reason).